### PR TITLE
Remove duplicate keyword from public package

### DIFF
--- a/public/package.json
+++ b/public/package.json
@@ -38,7 +38,6 @@
     "text",
     "computer",
     "vision",
-    "vision",
     "language",
     "multilingual",
     "english"


### PR DESCRIPTION
## Summary
- remove second `vision` keyword from `public/package.json`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882f186f3988331b12f2b734dd6e436